### PR TITLE
enabling server execution from maven commandline

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -46,6 +46,15 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                  <mainClass>massim.Server</mainClass>
+                  <executable>java</executable>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The pom changes allow to execute the server with the following command directly from source:

```
cd server/
mvn exec:java -Dexec.args="--monitor"
```
Prerequisite is that you once executed `mvn install`